### PR TITLE
Update AnylinkCloud RestAPI.md

### DIFF
--- a/docs/AnylinkCloud RestAPI.md
+++ b/docs/AnylinkCloud RestAPI.md
@@ -1730,8 +1730,7 @@ Request parameter example:
         "parent_id": "1",
         "cellphone": "123456",
         "email": "gfdgvdf@dfgdfg.dfg",
-        "telephone": 43566212344,
-        "undefined": "435662123dfg",
+        "telephone": "43566212344",
         "isadmin": "0",
         "type": 1
     }


### PR DESCRIPTION
https://github.com/anylinkcloud/AnyLink-Cloud/issues/126
Parameter "telephone" type is a string but in the Request parameter example:
"telephone": 43566212344
is an integer