### PR TITLE
Update AnylinkCloud RestAPI.md

### DIFF
--- a/docs/AnylinkCloud RestAPI.md
+++ b/docs/AnylinkCloud RestAPI.md
@@ -447,6 +447,7 @@ Return value: JSON
 | status    | String | return code: <br />**100**: successful <br />**103**: parameter error <br />**104**: invalid token<br />**111**: For some other errors, refer to the "msg" value. |
 | msg       | String | error message                                                |
 | data      | String | Result（0：success，3：overtime，others：failed）            |
+| adata     | String | It is an extension field used for other functions in AnylinkCloud. This field can be omitted here. |
 
 ```
 {


### PR DESCRIPTION
[API doc: #10 "adata" instead of data](https://github.com/anylinkcloud/AnyLink-Cloud/issues/123)
`adata` is an extension field used for other functions in AnylinkCloud. This field can be omitted here.